### PR TITLE
Remove vulnerable Go dependencies from kubectx installation

### DIFF
--- a/ubuntu/install.sh
+++ b/ubuntu/install.sh
@@ -128,7 +128,7 @@ install_kubectx() {
     sudo ln -s /opt/kubectx/kubens /usr/local/bin/kubens
 
     # Remove everything from the cloned kubectx repo except kubectx and kubens shell scripts and completion directory
-    sudo bash -c 'cd /opt/kubectx && find . -mindepth 1 -maxdepth 1 \
+    sudo sh -c 'cd /opt/kubectx && find . -mindepth 1 -maxdepth 1 \
       ! -name kubectx \
       ! -name kubens \
       ! -name completion \

--- a/ubuntu/install.sh
+++ b/ubuntu/install.sh
@@ -127,6 +127,13 @@ install_kubectx() {
     sudo ln -s /opt/kubectx/kubectx /usr/local/bin/kubectx
     sudo ln -s /opt/kubectx/kubens /usr/local/bin/kubens
 
+    # Remove everything from the cloned kubectx repo except kubectx and kubens shell scripts and completion directory
+    sudo bash -c 'cd /opt/kubectx && find . -mindepth 1 -maxdepth 1 \
+      ! -name kubectx \
+      ! -name kubens \
+      ! -name completion \
+      -exec rm -rf {} +'
+
     section "Configure completion scrips for plain zsh"
     info "Create directory: ~/.oh-my-zsh/custom/completions"
     mkdir -p ~/.oh-my-zsh/custom/completions


### PR DESCRIPTION
Files from https://github.com/ahmetb/kubectx contain Go files with defined dependencies to vulnerable Go libraries.
Since kubectx and kubens are shell scripts, those Go files are not needed to run these tools.

Removing all not needed Go files will improve Qualys scan results and will remove all findings related to dependent Go libraries. 